### PR TITLE
Fix issue with Spring Cloud Sleuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ public class BatchConfiguration {
     }
 
     @Bean
-    BatchConfigurer batchConfigurer(MongoTransactionManager mongoTransactionManager, MongoTemplate mongoTemplate) {
+    BatchConfigurer batchConfigurer(PlatformTransactionManager mongoTransactionManager, MongoTemplate mongoTemplate) {
         return MongodbBatchConfigurer.builder()
                 .mongoTemplate(mongoTemplate)
                 .mongoTransactionManager(mongoTransactionManager)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,4 @@
 group=io.github.wirednerd
 version=1.0.1
-springbootVersion=2.6.3
+springbootVersion=2.6.+
+springCloudVersion=2021.+

--- a/spring-batch-mongo-test/build.gradle
+++ b/spring-batch-mongo-test/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id "org.springframework.boot" version "${springbootVersion}"
-    id "io.freefair.lombok" version "6.4.0"
+    id "io.freefair.lombok" version "6.+"
 }
 
 apply plugin: 'java'
@@ -12,9 +12,16 @@ repositories {
 }
 
 dependencies {
+    if (springbootVersion.startsWith("2.5")) {
+        springCloudVersion = "2020.+"
+    }
+
+    implementation platform("org.springframework.cloud:spring-cloud-dependencies:${springCloudVersion}")
+
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-batch'
     implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+    implementation "org.springframework.cloud:spring-cloud-starter-sleuth"
 
     implementation project(":spring-batch-mongo")
 

--- a/spring-batch-mongo-test/src/main/java/io/gihub/wirednerd/mongo/BatchConfiguration.java
+++ b/spring-batch-mongo-test/src/main/java/io/gihub/wirednerd/mongo/BatchConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.data.mongodb.MongoDatabaseFactory;
 import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
@@ -22,7 +23,7 @@ public class BatchConfiguration {
     }
 
     @Bean
-    BatchConfigurer batchConfigurer(MongoTransactionManager mongoTransactionManager, MongoTemplate mongoTemplate) {
+    BatchConfigurer batchConfigurer(PlatformTransactionManager mongoTransactionManager, MongoTemplate mongoTemplate) {
         return MongodbBatchConfigurer.builder()
                 .mongoTemplate(mongoTemplate)
                 .mongoTransactionManager(mongoTransactionManager)

--- a/spring-batch-mongo/build.gradle
+++ b/spring-batch-mongo/build.gradle
@@ -1,10 +1,10 @@
 plugins {
     id 'java-library'
-    id "io.freefair.lombok" version "6.4.0"
+    id "io.freefair.lombok" version "6.+"
 //    id 'jacoco'
     id 'pmd'
     id 'project-report'
-    id 'info.solidsoft.pitest' version '1.7.0'
+    id 'info.solidsoft.pitest' version '1.+'
     id 'signing'
     id 'maven-publish'
 }
@@ -18,13 +18,13 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.batch:spring-batch-core:4.3.4'
-    implementation 'org.springframework.data:spring-data-mongodb:3.2.8'
-    implementation 'org.netbeans.api:org-netbeans-api-annotations-common:RELEASE126'
+    implementation 'org.springframework.batch:spring-batch-core:latest.release'
+    implementation 'org.springframework.data:spring-data-mongodb:3.2.+'  // version 3.2 for compatibility with boot 2.5
+    implementation 'org.netbeans.api:org-netbeans-api-annotations-common:latest.release'
 
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation "org.springframework.boot:spring-boot-starter-test:${springbootVersion}"
-    testImplementation 'org.mongodb:mongodb-driver-sync:4.4.1'
+    testImplementation 'org.mongodb:mongodb-driver-sync:latest.release'
 }
 
 compileJava {

--- a/spring-batch-mongo/src/main/java/io/github/wirednerd/springbatch/mongo/configuration/MongodbBatchConfigurer.java
+++ b/spring-batch-mongo/src/main/java/io/github/wirednerd/springbatch/mongo/configuration/MongodbBatchConfigurer.java
@@ -1,5 +1,6 @@
 package io.github.wirednerd.springbatch.mongo.configuration;
 
+import io.github.wirednerd.springbatch.mongo.explore.MongodbJobExplorer;
 import io.github.wirednerd.springbatch.mongo.repository.MongodbJobRepository;
 import lombok.NoArgsConstructor;
 import org.springframework.batch.core.configuration.annotation.BatchConfigurer;
@@ -16,13 +17,12 @@ import org.springframework.lang.Nullable;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 import org.springframework.util.Assert;
-import io.github.wirednerd.springbatch.mongo.explore.MongodbJobExplorer;
 
 import static io.github.wirednerd.springbatch.mongo.MongodbRepositoryConstants.*;
 
 /**
  * <p>Primary class for enabling Mongodb for storing Spring Batch job execution data.</p>
- * <p>{@link MongoTemplate} and {@link MongoTransactionManager} instances are required.
+ * <p>{@link MongoTemplate} and {@link PlatformTransactionManager} instances are required.
  * And it is stronly recommended to {@link EnableTransactionManagement}</p>
  * <p>Example Configuration:</p>
  * <pre>
@@ -36,7 +36,7 @@ import static io.github.wirednerd.springbatch.mongo.MongodbRepositoryConstants.*
  *     }
  *
  *     &#64;Bean
- *     BatchConfigurer batchConfigurer(MongoTransactionManager mongoTransactionManager, MongoTemplate mongoTemplate) {
+ *     BatchConfigurer batchConfigurer(PlatformTransactionManager mongoTransactionManager, MongoTemplate mongoTemplate) {
  *         return MongodbBatchConfigurer.builder()
  *                 .mongoTemplate(mongoTemplate)
  *                 .mongoTransactionManager(mongoTransactionManager)
@@ -73,7 +73,7 @@ public class MongodbBatchConfigurer implements BatchConfigurer {
      */
     public MongodbBatchConfigurer(final MongoTemplate mongoTemplate,
                                   final String jobCollectionName, final String counterCollectionName,
-                                  final MongoTransactionManager transactionManager,
+                                  final PlatformTransactionManager transactionManager,
                                   @Nullable final TaskExecutor taskExecutor) {
 
         Assert.notNull(mongoTemplate, "A MongoTemplate is required");
@@ -167,7 +167,7 @@ public class MongodbBatchConfigurer implements BatchConfigurer {
         private MongoTemplate mongoTemplate;
         private String jobCollectionName = DEFAULT_JOB_COLLECTION;
         private String counterCollectionName = DEFAULT_COUNTER_COLLECTION;
-        private MongoTransactionManager mongoTransactionManager;
+        private PlatformTransactionManager mongoTransactionManager;
         private TaskExecutor taskExecutor;
 
         /**
@@ -209,7 +209,7 @@ public class MongodbBatchConfigurer implements BatchConfigurer {
          * @param mongoTransactionManager that can be used to manage transactions on the provided {@link MongoTemplate}
          * @return {@link Builder}
          */
-        public Builder mongoTransactionManager(final MongoTransactionManager mongoTransactionManager) {
+        public Builder mongoTransactionManager(final PlatformTransactionManager mongoTransactionManager) {
             this.mongoTransactionManager = mongoTransactionManager;
             return this;
         }


### PR DESCRIPTION
Allow any type of PlatformTransactionManager for MongoTransactionManager.  Spring Cloud Sleuth wraps the MongoTransactionManager in a generic PlatformTransactionManager.